### PR TITLE
indicate payment mode by adding mode in result of verifyPayment (apple only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ will be in the result object:
         },
         "transactionId": "1000000102526671",
         "productId": "abc",
-        "platform": "apple"
+        "platform": "apple",
         "environment": "production"
 }
 ```

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ will be in the result object:
         "transactionId": "1000000102526671",
         "productId": "abc",
         "platform": "apple"
+        "environment": "production"
 }
 ```
 

--- a/lib/apple/index.js
+++ b/lib/apple/index.js
@@ -117,8 +117,8 @@ exports.verifyPayment = function (payment, cb) {
 		// 21007: this is a sandbox receipt, so take it there
 		if (error && error.status === 21007) {
 			return verify(apiUrls.sandbox, { json: jsonData }, function(err, res) {
-                checkReceipt(err, res, 'sandbox');
-            });
+                		checkReceipt(err, res, 'sandbox');
+            		});
 		}
 
 		return checkReceipt(error, resultString, 'production');

--- a/lib/apple/index.js
+++ b/lib/apple/index.js
@@ -90,7 +90,7 @@ exports.verifyPayment = function (payment, cb) {
 	}
 
 
-	function checkReceipt(error, result) {
+	function checkReceipt(error, result, mode) {
 		if (error) {
 			return cb(error);
 		}
@@ -107,6 +107,8 @@ exports.verifyPayment = function (payment, cb) {
 			return cb(new Error('Wrong bundle ID: ' + payment.packageName + ' (expected: ' + receipt.bid + ')'));
 		}
 
+        result.mode = mode;
+
 		return cb(null, result);
 	}
 
@@ -114,9 +116,11 @@ exports.verifyPayment = function (payment, cb) {
 	verify(apiUrls.production, { json: jsonData }, function (error, resultString) {
 		// 21007: this is a sandbox receipt, so take it there
 		if (error && error.status === 21007) {
-			return verify(apiUrls.sandbox, { json: jsonData }, checkReceipt);
+			return verify(apiUrls.sandbox, { json: jsonData }, function(err, res) {
+                checkReceipt(err, res, 'sandbox');
+            });
 		}
 
-		return checkReceipt(error, resultString);
+		return checkReceipt(error, resultString, 'production');
 	});
 };

--- a/lib/apple/index.js
+++ b/lib/apple/index.js
@@ -90,7 +90,7 @@ exports.verifyPayment = function (payment, cb) {
 	}
 
 
-	function checkReceipt(error, result, mode) {
+	function checkReceipt(error, result, environment) {
 		if (error) {
 			return cb(error);
 		}
@@ -107,7 +107,7 @@ exports.verifyPayment = function (payment, cb) {
 			return cb(new Error('Wrong bundle ID: ' + payment.packageName + ' (expected: ' + receipt.bid + ')'));
 		}
 
-        result.mode = mode;
+        	result.environment = environment;
 
 		return cb(null, result);
 	}


### PR DESCRIPTION
This PR adds payment mode indication, 
whether 'sandbox' or 'production' for apple platform

```
var platform = 'apple';
verifyPayment(platform, receipt, function(err, result) {
console.log(result.mode); // 'sandbox' or 'production'
});
```