### PR TITLE
Cache Google's access tokens per issuer

### DIFF
--- a/lib/google/index.js
+++ b/lib/google/index.js
@@ -32,7 +32,7 @@ exports.verifyPayment = function (payment, cb) {
 	}
 
 	/* jshint camelcase:false */
-	jwt.getToken(keyObject.client_email, keyObject.private_key, apiUrls.publisherScope, function (error, requestToken) {
+	jwt.getToken(keyObject.client_email, keyObject.private_key, apiUrls.publisherScope, function (error, token) {
 	/* jshint camelcase:true */
 		if (error) {
 			return cb(error);
@@ -42,9 +42,7 @@ exports.verifyPayment = function (payment, cb) {
 			payment.packageName,
 			payment.productId,
 			payment.receipt,
-			/* jshint camelcase:false */
-			requestToken.access_token
-			/* jshint camelcase:true */
+			token
 		);
 
 		https.get(requestUrl, null, function (error, res, responseString) {

--- a/lib/google/jwt.js
+++ b/lib/google/jwt.js
@@ -4,9 +4,20 @@ var https = require('../https');
 
 
 var oneHour = 60 * 60;
-
+// We will cache access tokens for reuse here
+var cache = {};
 
 exports.getToken = function (iss, key, scope, cb) {
+	// First, check if we already have a valid access token for this issuer in the cache
+	if (cache.hasOwnProperty(iss)) {
+		// Now we check if the token is still valid or already expired
+		if (cache[iss].expiry > Date.now()) {
+			// We have a valid access token for this issuer - we can simply return it
+			return setImmediate(cb, null, cache[iss].token);
+		}
+	}
+
+	// No token in cache - let's get one
 	var jwtToken = jwt.encode({
 		iss: iss,
 		scope: scope,
@@ -38,6 +49,18 @@ exports.getToken = function (iss, key, scope, cb) {
 			return cb(error);
 		}
 
-		return cb(null, responseObject);
+		// Save the access token and its expiry date to cache. Save the expiry in milliseconds as it
+		// will simplify the comparison code. Note that the expiry is a time in the future when the
+		// token expires, it is not the length of the token's validity.
+		cache[iss] = {
+			/* jshint camelcase:false */
+			token: responseObject.access_token,
+			// Allow for at least one minute reserve so that we avoid situations where the token expires
+			// in the next second or at a similarly inconvenient time
+			expiry: (responseObject.expires_in - 60) * 1000 + Date.now()
+			/* jshint camelcase:true */
+		};
+
+		return cb(null, cache[iss].token);
 	});
 };


### PR DESCRIPTION
This removes the need to fetch an access token for each purchase verification and should bring
significant performance boost.

Since we also know how long the token will be valid, we can proactively refresh the token if we
detect it is close to its expiry date.

Closes #17.