### PR TITLE
Add option to send shared secret for Apple App Store

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ receipt as returned by the iOS SDK (in which case it will be automatically base6
 Both productId and packageName (bundle ID) are optional, but when provided will be tested against.
 If the receipt does not match the provided values, an error will be returned.
 
+To verify auto-renewable subscriptions you need to provide `secret` field that contains your
+In-App Purchase Shared Secret.
+
 **The response**
 
 The response passed back to your callback will also be Apple specific. The entire parsed receipt

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var platforms = {
 };
 
 
-exports.verifyPayment = function (platform, payment, cb) {
+exports.verifyPayment = function (platform, payment, cb, sandbox) {
 	function syncError(error) {
 		process.nextTick(function () {
 			cb(error);
@@ -29,5 +29,5 @@ exports.verifyPayment = function (platform, payment, cb) {
 		result.platform = platform;
 
 		cb(null, result);
-	});
+	}, sandbox);
 };

--- a/lib/apple/index.js
+++ b/lib/apple/index.js
@@ -89,7 +89,7 @@ exports.verifyPayment = function (payment, cb, sandbox) {
 		});
 	}
 
-	if (typeof payment.secret !== 'undefined') {
+	if (payment.secret !== undefined) {
 		assert.equal(typeof payment.secret, 'string', 'Shared secret must be a string');
 		jsonData.password = payment.secret;
 	}

--- a/lib/apple/index.js
+++ b/lib/apple/index.js
@@ -72,7 +72,7 @@ function isBase64like(str) {
 }
 
 
-exports.verifyPayment = function (payment, cb) {
+exports.verifyPayment = function (payment, cb, sandbox) {
 	var jsonData = {};
 
 	try {
@@ -91,7 +91,7 @@ exports.verifyPayment = function (payment, cb) {
 
 	if (typeof payment.secret !== 'undefined') {
 		assert.equal(typeof payment.secret, 'string', 'Shared secret must be a string');
-		jsonData['password'] = payment.secret;
+		jsonData.password = payment.secret;
 	}
 
 	function checkReceipt(error, result, environment) {
@@ -116,8 +116,8 @@ exports.verifyPayment = function (payment, cb) {
 		return cb(null, result);
 	}
 
-
-	verify(apiUrls.production, { json: jsonData }, function (error, resultString) {
+	var url = sandbox ? apiUrls.sandbox : apiUrls.production;
+	verify(url, { json: jsonData }, function (error, resultString) {
 		// 21007: this is a sandbox receipt, so take it there
 		if (error && error.status === 21007) {
 			return verify(apiUrls.sandbox, { json: jsonData }, function(err, res) {

--- a/lib/apple/index.js
+++ b/lib/apple/index.js
@@ -89,10 +89,10 @@ exports.verifyPayment = function (payment, cb) {
 		});
 	}
 
-  if (typeof payment.secret !== 'undefined') {
+	if (typeof payment.secret !== 'undefined') {
 		assert.equal(typeof payment.secret, 'string', 'Shared secret must be a string');
-    jsonData['password'] = payment.secret;
-  }
+		jsonData['password'] = payment.secret;
+	}
 
 	function checkReceipt(error, result, environment) {
 		if (error) {

--- a/lib/apple/index.js
+++ b/lib/apple/index.js
@@ -89,6 +89,10 @@ exports.verifyPayment = function (payment, cb) {
 		});
 	}
 
+  if (typeof payment.secret !== 'undefined') {
+		assert.equal(typeof payment.secret, 'string', 'Shared secret must be a string');
+    jsonData['password'] = payment.secret;
+  }
 
 	function checkReceipt(error, result, environment) {
 		if (error) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iap",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "In-app purchases for Node.js (Apple, Google)",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iap",
-  "version": "0.5.1",
+  "version": "0.5.0",
   "description": "In-app purchases for Node.js (Apple, Google)",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
When using auto-renewing subscription, it is required by Apple to send a shared secret with the request. This commit adds this feature.
