### PR TITLE
Use shared secret for apple receipts

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ var payment = {
 	receipt: 'receipt data',   // always required
 	productId: 'abc',
 	packageName: 'my.app',
+	secret: 'password',
 	subscription: true	// optional, if google play subscription
 };
 
@@ -51,6 +52,9 @@ receipt as returned by the iOS SDK (in which case it will be automatically base6
 
 Both productId and packageName (bundle ID) are optional, but when provided will be tested against.
 If the receipt does not match the provided values, an error will be returned.
+
+To verify auto-renewable subscriptions you need to provide `secret` field that
+contains your In-App Purchase Shared Secret
 
 **The response**
 

--- a/bin/verify-apple.js
+++ b/bin/verify-apple.js
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 
-var argv = require('minimist')(process.argv.slice(2), { string: ['productId', 'packageName', 'receipt'] });
+var argv = require('minimist')(process.argv.slice(2), { string: ['productId', 'packageName', 'receipt', 'secret'] });
 
 if (argv.help) {
-	console.log('Usage: ./verfiy.js --productId=abc --packageName=my.app --receipt=\'receipt-data\'');
+	console.log('Usage: ./verfiy.js --productId=abc --packageName=my.app --receipt=\'receipt-data\' --secret=\'shared secret\'');
 	process.exit(1);
 }
 

--- a/lib/apple/index.js
+++ b/lib/apple/index.js
@@ -102,13 +102,13 @@ exports.verifyPayment = function (payment, cb) {
 		var receipt = result.receipt;
 
 		/* jshint camelcase:false */
-		if (payment.hasOwnProperty('productId') && payment.productId !== receipt.product_id) {
-			return cb(new Error('Wrong product ID: ' + payment.productId + ' (expected: ' + receipt.product_id + ')'));
+		if (payment.hasOwnProperty('productId')) {
+			return cb(new Error('product ID not found'));
 		}
 		/* jshint camelcase:true */
 
-		if (payment.hasOwnProperty('packageName') && payment.packageName !== receipt.bid) {
-			return cb(new Error('Wrong bundle ID: ' + payment.packageName + ' (expected: ' + receipt.bid + ')'));
+		if (payment.hasOwnProperty('packageName')) {
+			return cb(new Error('Package name not found'));
 		}
 
         	result.environment = environment;

--- a/lib/apple/index.js
+++ b/lib/apple/index.js
@@ -102,13 +102,13 @@ exports.verifyPayment = function (payment, cb) {
 		var receipt = result.receipt;
 
 		/* jshint camelcase:false */
-		if (!payment.hasOwnProperty('productId')) {
-			return cb(new Error('product ID not found'));
+		if (payment.hasOwnProperty('productId') && payment.productId !== receipt.product_id) {
+			return cb(new Error('Wrong product ID: ' + payment.productId + ' (expected: ' + receipt.product_id + ')'));
 		}
 		/* jshint camelcase:true */
 
-		if (!payment.hasOwnProperty('packageName')) {
-			return cb(new Error('Package name not found'));
+		if (payment.hasOwnProperty('packageName') && payment.packageName !== receipt.bid) {
+			return cb(new Error('Wrong bundle ID: ' + payment.packageName + ' (expected: ' + receipt.bid + ')'));
 		}
 
         result.environment = environment;

--- a/lib/apple/index.js
+++ b/lib/apple/index.js
@@ -89,6 +89,10 @@ exports.verifyPayment = function (payment, cb) {
 		});
 	}
 
+	if (payment.secret !== undefined) {
+		assert.equal(typeof payment.secret, 'string', 'Shared secret must be a string');
+		jsonData.password = payment.secret;
+	}
 
 	function checkReceipt(error, result, environment) {
 		if (error) {

--- a/lib/apple/index.js
+++ b/lib/apple/index.js
@@ -102,16 +102,16 @@ exports.verifyPayment = function (payment, cb) {
 		var receipt = result.receipt;
 
 		/* jshint camelcase:false */
-		if (payment.hasOwnProperty('productId')) {
+		if (!payment.hasOwnProperty('productId')) {
 			return cb(new Error('product ID not found'));
 		}
 		/* jshint camelcase:true */
 
-		if (payment.hasOwnProperty('packageName')) {
+		if (!payment.hasOwnProperty('packageName')) {
 			return cb(new Error('Package name not found'));
 		}
 
-        	result.environment = environment;
+        result.environment = environment;
 
 		return cb(null, result);
 	}


### PR DESCRIPTION
### Description
When shared secret is provided for an Apple subscription, use it when accessing receipt information. This applies to both the required package as well as the binary for console. 

In addition to what was addressed in the Resolves, we added a few more additions. ~~We removed the product id and package name comparison to support receipt lookup without prior knowledge of the receipt's product id or bundle id. By still requiring the field, clients can provide a null object when not applicable. This will support flows that require a package id and bundle id as well as those that don't.~~

### Test
Ran: `./verify-apple.js --productId=null --packageName=null --receipt='<payload>' -- secret='<password>'`

Received: https://gist.github.com/KLVTZ/7ce1ab1d9d75c9cab731205abd2eb95f

### Resolves
#5, #8 - Adopts original condition with assertion. Includes binary for apple verification from console.
#21 - Adopts readme but removes outstanding sandbox vs. production issues

### Outstanding
#11 would be a nice addition in relation to this PR for the next version release. Although it does seem to need a few adjustments depending on how we handle conditions.