### PR TITLE
Support Roku purchase verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ var payment = {
 	productId: 'abc',
 	packageName: 'my.app',
 	subscription: true,	// optional, if google play subscription
-	devToken: 'developer id' // optional, if roku subscription
+	devToken: 'developer id' // required, if roku subscription
 };
 
 iap.verifyPayment(platform, payment, function (error, response) {

--- a/README.md
+++ b/README.md
@@ -5,15 +5,11 @@ written by Paul Crawford, I wanted a pure JavaScript implementation of in-app pu
 I also wanted to add support for other app stores, and not just limit this to Apple. The `iap`
 module is exactly that. Pull requests to add support for other platforms are very welcome!
 
-
-
 ## Installation
 
 ```sh
 npm install iap
 ```
-
-
 
 ## Usage
 
@@ -27,7 +23,8 @@ var payment = {
 	receipt: 'receipt data',   // always required
 	productId: 'abc',
 	packageName: 'my.app',
-	subscription: true	// optional, if google play subscription
+	subscription: true,	// optional, if google play subscription
+	devToken: 'developer id' // optional, if roku subscription
 };
 
 iap.verifyPayment(platform, payment, function (error, response) {
@@ -37,8 +34,6 @@ iap.verifyPayment(platform, payment, function (error, response) {
 
 The receipt you pass must conform to the requirements of the backend you are verifying with. Read
 the next chapter for more information on the format.
-
-
 
 ## Supported platforms
 
@@ -116,6 +111,48 @@ receipt sub-object.
 }
 ```
 
+### Roku
+
+The receiept string represents the transaction returned from a channel or
+product purchase.
+
+A developer ID is required.
+
+**The response**
+
+The response passed back to your callback will also be Roku specific. The entire
+parsed receipt will be in the result object:
+
+```json
+{
+	"receipt": {
+		"errorCode": null,
+		"errorDetails": null,
+		"errorMessage": "",
+		"status": 0,
+		"amount": 4.99,
+		"cancelled": false,
+		"channelId": 70391,
+		"channelName": "abc",
+		"couponCode": null,
+		"currency": "usd",
+		"expirationDate": 1488337344000,
+		"originalPurchaseDate": 1483153344000,
+		"partnerReferenceId": null,
+		"productId": "5KAZUPGB.0RF0",
+		"productName": "BASIC - US MONTHLY",
+		"purchaseDate": 1483153344000,
+		"quantity": 1,
+		"rokuCustomerId": "5e56c4c4d7d1504f813c630c2790e54a",
+		"tax": 0,
+		"total": 0,
+		"transactionId": "380e9932-ed9a-48e8-bd66-a6ec00b5efd1"
+	},
+	"transactionId": "380e9932-ed9a-48e8-bd66-a6ec00b5efd1",
+	"productId": "abc",
+	"platform": "roku"
+}
+```
 
 ### All Platforms
 
@@ -127,12 +164,9 @@ will be included:
 * platform, which is always the platform you passed.
 
 
-
 ## License
 
 MIT
-
-
 
 ## References
 
@@ -152,7 +186,7 @@ MIT
  * https://bitbucket.org/gooroo175/google-play-purchase-validator/src/d88278c30df0d0dc51b852b7bcab5f40e3a30923/index.js?at=master
  * https://github.com/machadogj/node-google-bigquery
  * https://github.com/extrabacon/google-oauth-jwt/blob/master/lib/request-jwt.js
- 
+
 **API Reference**
 
  * https://developer.android.com/google/play/billing/gp-purchase-status-api.html
@@ -164,9 +198,15 @@ MIT
  * https://developers.google.com/android-publisher/api-ref/purchases/products/get
  * http://developer.android.com/google/play/billing/billing_testing.html
  * http://stackoverflow.com/questions/24323207/use-service-account-to-verify-google-inapppurchase
- 
+
 **Receipt Generation**
 
  * http://developer.android.com/training/in-app-billing/preparing-iab-app.html
  * http://developer.android.com/tools/publishing/app-signing.html
  * http://developer.android.com/google/play/billing/api.html#managed
+
+### Roku References
+
+**API Reference**
+
+ * https://sdkdocs.roku.com/display/sdkdoc/Web+Service+API#WebServiceAPI-/listen/transaction-service.svc/validate-transaction/{devtoken}/{transactionid}

--- a/README.md
+++ b/README.md
@@ -20,12 +20,12 @@ var iap = require('iap');
 
 var platform = 'apple';
 var payment = {
-	receipt: 'receipt data',   // always required
+	receipt: 'receipt data', // always required
 	productId: 'abc',
 	packageName: 'my.app',
 	secret: 'password',
 	subscription: true,	// optional, if google play subscription
-	devToken: 'developer id' // required, if roku subscription
+	devToken: 'developer id' // required, if roku
 };
 
 iap.verifyPayment(platform, payment, function (error, response) {

--- a/bin/verify-roku.js
+++ b/bin/verify-roku.js
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+
+var argv = require('minimist')(process.argv.slice(2), { string: ['devToken', 'receipt'] });
+
+if (argv.help) {
+	console.log('Usage: ./verfiy.js --devToken=\'developer-id\' --receipt=\'transaction-data\'');
+	process.exit(1);
+}
+
+var iap = require('../index.js');
+
+var platform = 'roku';
+var payment = argv;
+
+iap.verifyPayment(platform, payment, function (error, result) {
+	if (error) {
+		return console.log(error);
+	}
+
+	console.log('Verified:');
+	console.log(JSON.stringify(result, null, '\t'));
+});

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 var platforms = {
 	apple: require('./lib/apple'),
-	google: require('./lib/google')
+	google: require('./lib/google'),
+	roku: require('./lib/roku')
 };
 
 

--- a/lib/roku/index.js
+++ b/lib/roku/index.js
@@ -39,7 +39,9 @@ exports.verifyPayment = function (payment, cb) {
 		if (resultObject.errorMessage) {
 			return cb(new Error(resultObject.errorMessage));
 		}
-
+		
+		// parse non-standard date property (i.e. /Date(1293034567877)/) in
+		// order to extract date by milliseconds
 		resultObject.expirationDate = new Date(parseInt(resultObject.expirationDate.substr(6), 10)).getTime();
 		resultObject.originalPurchaseDate = new Date(parseInt(resultObject.originalPurchaseDate.substr(6), 10)).getTime();
 		resultObject.purchaseDate = new Date(parseInt(resultObject.purchaseDate.substr(6), 10)).getTime();

--- a/lib/roku/index.js
+++ b/lib/roku/index.js
@@ -9,7 +9,7 @@ exports.verifyPayment = function (payment, cb) {
 	try {
 		assert.equal(typeof payment.devToken, 'string', 'Developer ID must be a string');
 		assert.equal(typeof payment.receipt, 'string', 'Receipt must be a string');
-		assert.equal(payment.receipt.match(/[\d|\w]/g).length, 32, 'Receipt must contain 32 digits');
+		assert.equal(payment.receipt.match(/\w/g).length, 32, 'Receipt must contain 32 digits');
 		assert.equal(payment.receipt.match(/-/g).length, 4, 'Receipt must contain 4 dashes');
 	} catch (error) {
 		return process.nextTick(function () {
@@ -36,7 +36,7 @@ exports.verifyPayment = function (payment, cb) {
 			return cb(error);
 		}
 
-		if (resultObject.errorMessage !== '') {
+		if (resultObject.errorMessage) {
 			return cb(new Error(resultObject.errorMessage));
 		}
 

--- a/lib/roku/index.js
+++ b/lib/roku/index.js
@@ -40,9 +40,9 @@ exports.verifyPayment = function (payment, cb) {
 			return cb(new Error(resultObject.errorMessage));
 		}
 
-		resultObject.expirationDate = new Date(parseInt(resultObject.expirationDate.substr(6))).getTime();
-		resultObject.originalPurchaseDate = new Date(parseInt(resultObject.originalPurchaseDate.substr(6))).getTime();
-		resultObject.purchaseDate = new Date(parseInt(resultObject.purchaseDate.substr(6))).getTime();
+		resultObject.expirationDate = new Date(parseInt(resultObject.expirationDate.substr(6), 10)).getTime();
+		resultObject.originalPurchaseDate = new Date(parseInt(resultObject.originalPurchaseDate.substr(6), 10)).getTime();
+		resultObject.purchaseDate = new Date(parseInt(resultObject.purchaseDate.substr(6), 10)).getTime();
 
 		cb(null, {
 			receipt: resultObject,

--- a/lib/roku/index.js
+++ b/lib/roku/index.js
@@ -1,0 +1,53 @@
+var assert = require('assert');
+var https = require('../https');
+
+var apiUrls = {
+	production: 'https://apipub.roku.com/listen/transaction-service.svc/validate-transaction'
+};
+
+exports.verifyPayment = function (payment, cb) {
+	try {
+		assert.equal(typeof payment.devToken, 'string', 'Developer ID must be a string');
+		assert.equal(typeof payment.receipt, 'string', 'Receipt must be a string');
+		assert.equal(payment.receipt.match(/[\d|\w]/g).length, 32, 'Receipt must contain 32 digits');
+		assert.equal(payment.receipt.match(/-/g).length, 4, 'Receipt must contain 4 dashes');
+	} catch (error) {
+		return process.nextTick(function () {
+			cb(error);
+		});
+	}
+
+	var requestUrl = apiUrls.production + '/' + payment.devToken + '/' + payment.receipt;
+
+	https.get(requestUrl, {headers: {Accept: 'application/json'}}, function (error, res, resultString) {
+		if (error) {
+			return cb(error);
+		}
+
+		if (res.statusCode !== 200) {
+				return cb(new Error('Received ' + res.statusCode + ' status code with body: ' + resultString));
+		}
+
+		var resultObject = null;
+
+		try {
+			resultObject = JSON.parse(resultString);
+		} catch (error) {
+			return cb(error);
+		}
+
+		if (resultObject.errorMessage !== '') {
+			return cb(new Error(resultObject.errorMessage));
+		}
+
+		resultObject.expirationDate = new Date(parseInt(resultObject.expirationDate.substr(6))).getTime();
+		resultObject.originalPurchaseDate = new Date(parseInt(resultObject.originalPurchaseDate.substr(6))).getTime();
+		resultObject.purchaseDate = new Date(parseInt(resultObject.purchaseDate.substr(6))).getTime();
+
+		cb(null, {
+			receipt: resultObject,
+			transactionId: resultObject.transactionId,
+			productId: resultObject.productId
+		});
+	});
+};

--- a/lib/roku/index.js
+++ b/lib/roku/index.js
@@ -40,8 +40,8 @@ exports.verifyPayment = function (payment, cb) {
 			return cb(new Error(resultObject.errorMessage));
 		}
 		
-		// parse non-standard date property (i.e. /Date(1293034567877)/) in
-		// order to extract date by milliseconds
+		// parse non-standard date properties (i.e. /Date(1483242628000-0800)/)
+		// in order to extract value by milliseconds
 		resultObject.expirationDate = new Date(parseInt(resultObject.expirationDate.substr(6), 10)).getTime();
 		resultObject.originalPurchaseDate = new Date(parseInt(resultObject.originalPurchaseDate.substr(6), 10)).getTime();
 		resultObject.purchaseDate = new Date(parseInt(resultObject.purchaseDate.substr(6), 10)).getTime();

--- a/lib/roku/index.js
+++ b/lib/roku/index.js
@@ -1,7 +1,7 @@
 var assert = require('assert');
 var https = require('../https');
 
-var apiUrls = {
+var apiUrl = {
 	production: 'https://apipub.roku.com/listen/transaction-service.svc/validate-transaction'
 };
 
@@ -17,7 +17,7 @@ exports.verifyPayment = function (payment, cb) {
 		});
 	}
 
-	var requestUrl = apiUrls.production + '/' + payment.devToken + '/' + payment.receipt;
+	var requestUrl = apiUrl.production + '/' + payment.devToken + '/' + payment.receipt;
 
 	https.get(requestUrl, {headers: {Accept: 'application/json'}}, function (error, res, resultString) {
 		if (error) {

--- a/lib/roku/index.js
+++ b/lib/roku/index.js
@@ -25,7 +25,7 @@ exports.verifyPayment = function (payment, cb) {
 		}
 
 		if (res.statusCode !== 200) {
-				return cb(new Error('Received ' + res.statusCode + ' status code with body: ' + resultString));
+			return cb(new Error('Received ' + res.statusCode + ' status code with body: ' + resultString));
 		}
 
 		var resultObject = null;


### PR DESCRIPTION
Description
-----------
The following provides support for roku receipt verification. We adopt the same
response pattern from Apple and Google receipts. In addition, we provide
baseline assertion to validate the health of the receipt provided. We also parse
and format date objects that are returned from Roku's API.

Readme has been updated with instructions

Test
----
- /verify-roku.js --devToken='token' --receipt='receipt'
- https://gist.github.com/KLVTZ/08e803020ebe8650e28e844090cd1f89

Future
------
As we progress towards more TV applications internally, we might contribute
amazon's fire-tv into this service. Something we look forward to doing.