### PR TITLE
Support Amazon purchase verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ iap.verifyPayment(platform, payment, function (error, response) {
 	/* your code */
 });
 ```
+
 The receipt you pass must conform to the requirements of the backend you are verifying with. Read
 the next chapter for more information on the format.
 
@@ -247,7 +248,6 @@ will be included:
 MIT
 
 ## References
-<<<<<<< HEAD
 
 ### Amazon References
 **Code Inspiration**

--- a/README.md
+++ b/README.md
@@ -5,15 +5,11 @@ written by Paul Crawford, I wanted a pure JavaScript implementation of in-app pu
 I also wanted to add support for other app stores, and not just limit this to Apple. The `iap`
 module is exactly that. Pull requests to add support for other platforms are very welcome!
 
-
-
 ## Installation
 
 ```sh
 npm install iap
 ```
-
-
 
 ## Usage
 
@@ -24,24 +20,58 @@ var iap = require('iap');
 
 var platform = 'apple';
 var payment = {
-	receipt: 'receipt data',   // always required
+	receipt: 'receipt data', // always required
 	productId: 'abc',
 	packageName: 'my.app',
 	secret: 'password',
-	subscription: true	// optional, if google play subscription
+	subscription: true,	// optional, if google play subscription
+	userId: 'user id' // required, if amazon
 };
 
 iap.verifyPayment(platform, payment, function (error, response) {
 	/* your code */
 });
 ```
-
 The receipt you pass must conform to the requirements of the backend you are verifying with. Read
 the next chapter for more information on the format.
 
-
-
 ## Supported platforms
+
+### Amazon 
+
+**The payment object**
+
+The receipt string represents the transaction returned from a channel or product
+purchase.
+
+A Shared secret and user ID is required.
+
+**The response**
+
+The response passed back to your callback will also be Amazon specific. The entire parsed receipt
+will be in the result object:
+
+```json
+{
+	"receipt": {
+		"betaProduct": false,
+		"cancelDate": null,
+		"parentProductId": null,
+		"productId": "com.amazon.iapsamplev2.gold_medal",
+		"productType": "CONSUMABLE",
+		"purchaseDate": 1399070221749,
+		"quantity": 1,
+		"receiptId": "wE1EG1gsEZI9q9UnI5YoZ2OxeoVKPdR5bvPMqyKQq5Y=:1:11",
+		"renewalDate": null,
+		"term": null,
+		"termSku": null,
+		"testTransaction": false
+	},
+	"transactionId": "wE1EG1gsEZI9q9UnI5YoZ2OxeoVKPdR5bvPMqyKQq5Y=:1:11",
+	"productId": "com.amazon.iapsamplev2.gold_medal",
+	"platform": "amazon"
+}
+```
 
 ### Apple
 
@@ -87,7 +117,6 @@ will be in the result object:
 }
 ```
 
-
 ### Google Play
 
 **The payment object**
@@ -120,7 +149,6 @@ receipt sub-object.
 }
 ```
 
-
 ### All Platforms
 
 Regardless of the platform used, besides the platform-specific receipt, the following properties
@@ -130,15 +158,20 @@ will be included:
 * productId, which specifies what was purchased.
 * platform, which is always the platform you passed.
 
-
-
 ## License
 
 MIT
 
-
-
 ## References
+
+### Amazon References
+**Code Inspiration**
+
+ * https://github.com/may215/amazon_iap 
+
+**API Reference**
+
+ * https://developer.amazon.com/public/apis/earn/in-app-purchasing/docs-v2/verifying-receipts-in-iap	
 
 ### Apple References
 **Code Inspiration**
@@ -148,7 +181,6 @@ MIT
 **API Reference**
 
  * 	https://developer.apple.com/library/ios/releasenotes/General/ValidateAppStoreReceipt/Chapters/ValidateRemotely.html
-
 
 ### Google Play References
 **Code Inspiration**

--- a/bin/verify-amazon.js
+++ b/bin/verify-amazon.js
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+
+var argv = require('minimist')(process.argv.slice(2), { string: ['secret', 'userId', 'receipt'] });
+
+if (argv.help) {
+	console.log('Usage: ./verfiy.js --secret=\'shared-secret\' --userId=\'amazon-user\' --receipt=\'receipt-data\'');
+	process.exit(1);
+}
+
+var iap = require('../index.js');
+
+var platform = 'amazon';
+var payment = argv;
+
+iap.verifyPayment(platform, payment, function (error, result) {
+	if (error) {
+		return console.log(error);
+	}
+
+	console.log('Verified:');
+	console.log(JSON.stringify(result, null, '\t'));
+});

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 var platforms = {
+	amazon: require('./lib/amazon'),
 	apple: require('./lib/apple'),
 	google: require('./lib/google')
 };

--- a/lib/amazon/index.js
+++ b/lib/amazon/index.js
@@ -1,0 +1,60 @@
+var assert = require('assert');
+var https = require('../https');
+
+var apiUrl = {
+	production: 'https://appstore-sdk.amazon.com/version/1.0/verifyReceiptId/developer/'
+};
+
+exports.verifyPayment = function (payment, cb) {
+	try {
+		assert.equal(typeof payment.secret, 'string', 'Shared secret must be a string');
+		assert.equal(typeof payment.userId, 'string', 'User ID must be a string');
+		assert.equal(typeof payment.receipt, 'string', 'Receipt must be a string');
+	} catch (error) {
+		return process.nextTick(function () {
+			cb(error);
+		});
+	}
+
+	var requestUrl = apiUrl.production + payment.secret + '/user/' + payment.userId + '/receiptId/' + payment.receipt;
+
+	https.get(requestUrl, null, function (error, res, resultString) {
+		if (error) {
+			return cb(error);
+		}
+
+		var resultObject = null;
+
+		try {
+			resultObject = JSON.parse(resultString);
+		} catch (error) {
+			return cb(error);
+		}
+
+		if (res.statusCode === 400) {
+				return cb(new Error('receiptId is invalid, or no transaction was found for this receiptId'));
+		}
+
+		if (res.statusCode === 496 ) {
+				return cb(new Error('Invalid sharedSecret'));
+		}
+
+		if (res.statusCode === 497) {
+				return cb(new Error('Invalid User ID'));
+		}
+
+		if (res.statusCode === 500) {
+				return cb(new Error('There was an Internal Servor Error'));
+		}
+
+		if (res.statusCode !== 200) {
+				return cb(new Error('Unknown operation exception'));
+		}
+
+		cb(null, {
+			receipt: resultObject,
+			transactionId: resultObject.receiptId,
+			productId: resultObject.productId
+		});
+	});
+};

--- a/lib/amazon/index.js
+++ b/lib/amazon/index.js
@@ -32,23 +32,23 @@ exports.verifyPayment = function (payment, cb) {
 		}
 
 		if (res.statusCode === 400) {
-				return cb(new Error('receiptId is invalid, or no transaction was found for this receiptId'));
+			return cb(new Error('receiptId is invalid, or no transaction was found for this receiptId'));
 		}
 
 		if (res.statusCode === 496 ) {
-				return cb(new Error('Invalid sharedSecret'));
+			return cb(new Error('Invalid sharedSecret'));
 		}
 
 		if (res.statusCode === 497) {
-				return cb(new Error('Invalid User ID'));
+			return cb(new Error('Invalid User ID'));
 		}
 
 		if (res.statusCode === 500) {
-				return cb(new Error('There was an Internal Servor Error'));
+			return cb(new Error('There was an Internal Servor Error'));
 		}
 
 		if (res.statusCode !== 200) {
-				return cb(new Error('Unknown operation exception'));
+			return cb(new Error('Unknown operation exception'));
 		}
 
 		cb(null, {


### PR DESCRIPTION
Description
-----------
The following provides support for amazon receipt verification. We adopt the same
response pattern from Apple and Roku receipts. In addition, we provide
baseline assertion to validate the health of the receipt provided.

Readme has been updated with instructions

Test
----
- /verify-amazon.js --secret='token' --userId='userIdentity' --receipt='receipt'
- https://gist.github.com/KLVTZ/ad9951b8bc32e370d20f50a8ad267388

Why?
------
I will refer to the following comment on why this initiative would be helpful for this project:
https://github.com/Wizcorp/node-iap/pull/25#issuecomment-280397906

We are currently using a fork version of node-iap in production when verifying amazon purchases:

https://www.amazon.com/TEN-The-Enthusiast-Network-LLC/dp/B06XP4F49R/ref=sr_1_1?ie=UTF8&qid=1504654174&sr=8-1&keywords=motortrendondemand