### PR TITLE
Support single entry ios latest_receipt_info

### DIFF
--- a/lib/apple/index.js
+++ b/lib/apple/index.js
@@ -52,7 +52,7 @@ function parseResult(result) {
 
 	/* jshint camelcase:false */
 	if (result.hasOwnProperty('latest_receipt_info')) {
-		if(Array.isArray(result.latest_receipt_info) && result.latest_receipt_info.length > 1) {
+		if(Array.isArray(result.latest_receipt_info) && result.latest_receipt_info.length > 0) {
 			latestReceiptInfo = result.latest_receipt_info.sort(function (a, b) {
 				return parseInt(a.transaction_id, 10)  - parseInt(b.transaction_id, 10);
 			});

--- a/lib/apple/index.js
+++ b/lib/apple/index.js
@@ -30,6 +30,7 @@ function getReceiptFieldValue(receipt, field) {
 	return null;
 }
 
+// RESULT DOCS https://developer.apple.com/library/content/releasenotes/General/ValidateAppStoreReceipt/Chapters/ValidateRemotely.html
 function parseResult(result) {
 	result = JSON.parse(result);
 
@@ -50,18 +51,26 @@ function parseResult(result) {
 	var transactionId = getReceiptFieldValue(result.receipt, 'transaction_id');
 
 	/* jshint camelcase:false */
-	if (result.hasOwnProperty('latest_receipt_info') && result.latest_receipt_info[0]) {
-		latestReceiptInfo = result.latest_receipt_info.sort(function (a, b) {
-			return parseInt(a.transaction_id, 10)  - parseInt(b.transaction_id, 10);
-		});
+	if (result.hasOwnProperty('latest_receipt_info')) {
+		if(Array.isArray(result.latest_receipt_info) && result.latest_receipt_info.length > 1) {
+			latestReceiptInfo = result.latest_receipt_info.sort(function (a, b) {
+				return parseInt(a.transaction_id, 10)  - parseInt(b.transaction_id, 10);
+			});
 
-		productId = latestReceiptInfo[latestReceiptInfo.length - 1].product_id;
-		transactionId = latestReceiptInfo[latestReceiptInfo.length - 1].transaction_id;
+			productId = latestReceiptInfo[latestReceiptInfo.length - 1].product_id;
+			transactionId = latestReceiptInfo[latestReceiptInfo.length - 1].transaction_id;
+		} else if(result.latest_receipt_info && result.latest_receipt_info.transaction_id) {
+			latestReceiptInfo = [result.latest_receipt_info];
+
+			productId = result.latest_receipt_info.product_id;
+			transactionId = result.latest_receipt_info.transaction_id;
+		}
 	}
 
 	return {
 		receipt: result.receipt,
 		latestReceiptInfo: latestReceiptInfo,
+		latestExpiredReceiptInfo: result.latest_expired_receipt_info,
 		productId: productId,
 		transactionId: transactionId
 	};


### PR DESCRIPTION
It appears that subscriptions will not be an array data type if subscriptions have a trial and you validate the receipt after the trial expiration.