### PR TITLE
Support exclude-old-transactions for Apple receipts

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,15 @@ If the receipt does not match the provided values, an error will be returned.
 To verify auto-renewable subscriptions you need to provide `secret` field that
 contains your In-App Purchase Shared Secret
 
+Apple supports returning only the most recent transaction for auto-renewable subscriptions via their (exclude-old-transactions)[https://developer.apple.com/library/content/releasenotes/General/ValidateAppStoreReceipt/Chapters/ValidateRemotely.html] option. This can greatly save on bandwidth for users that have more than one transaction. To enable this, pass `excludeOldTransactions` on the payment object:
+
+```javascript
+let payment = {
+  ...
+  excludeOldTransactions: true
+}
+```
+
 **The response**
 
 The response passed back to your callback will also be Apple specific. The entire parsed receipt

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ If the receipt does not match the provided values, an error will be returned.
 To verify auto-renewable subscriptions you need to provide `secret` field that
 contains your In-App Purchase Shared Secret
 
-Apple supports returning only the most recent transaction for auto-renewable subscriptions via their (exclude-old-transactions)[https://developer.apple.com/library/content/releasenotes/General/ValidateAppStoreReceipt/Chapters/ValidateRemotely.html] option. This can greatly save on bandwidth for users that have more than one transaction. To enable this, pass `excludeOldTransactions` on the payment object:
+Apple supports returning only the most recent transaction for auto-renewable subscriptions via their [exclude-old-transactions](https://developer.apple.com/library/content/releasenotes/General/ValidateAppStoreReceipt/Chapters/ValidateRemotely.html) option. This can greatly save on bandwidth for users that have more than one transaction. To enable this, pass `excludeOldTransactions` on the payment object:
 
 ```javascript
 let payment = {

--- a/lib/apple/index.js
+++ b/lib/apple/index.js
@@ -121,12 +121,12 @@ exports.verifyPayment = function (payment, cb) {
 	}
 
 	if (payment.secret !== undefined) {
-		assert.equal(typeof payment.secret, 'string', 'Shared secret must be a string');
+		assert.equal(typeof payment.secret, 'string', 'payment.secret must be a string');
 		jsonData.password = payment.secret;
 	}
 	
 	if (payment.excludeOldTransactions !== undefined) {
-		assert.equal(typeof payment.excludeOldTransactions, 'boolean', 'Exclude old transactions must be a boolean');
+		assert.equal(typeof payment.excludeOldTransactions, 'boolean', 'payment.excludeOldTransactions must be a boolean');
 		jsonData['exclude-old-transactions'] = payment.excludeOldTransactions;
 	}
 

--- a/lib/apple/index.js
+++ b/lib/apple/index.js
@@ -124,6 +124,11 @@ exports.verifyPayment = function (payment, cb) {
 		assert.equal(typeof payment.secret, 'string', 'Shared secret must be a string');
 		jsonData.password = payment.secret;
 	}
+	
+	if (payment.excludeOldTransactions !== undefined) {
+		assert.equal(typeof payment.excludeOldTransactions, 'boolean', 'Exclude old transactions must be a boolean');
+		jsonData['exclude-old-transactions'] = payment.excludeOldTransactions;
+	}
 
 	function checkReceipt(error, result, environment) {
 		if (error) {


### PR DESCRIPTION
Adds support for `exclude-old-transactions` when verifying Apple receipts:
https://developer.apple.com/library/content/releasenotes/General/ValidateAppStoreReceipt/Chapters/ValidateRemotely.html