### PR TITLE
Bumps jwt-simple

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -722,9 +722,9 @@
       "dev": true
     },
     "jwt-simple": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/jwt-simple/-/jwt-simple-0.2.0.tgz",
-      "integrity": "sha1-ceTkm0XPLigg1FdoaLwKjjc6lnA="
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/jwt-simple/-/jwt-simple-0.5.1.tgz",
+      "integrity": "sha1-eeoBiRth3mto4T5nwLS1vak3spQ="
     },
     "levn": {
       "version": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -25,9 +25,9 @@
   "author": "Ron Korving <rkorving@wizcorp.jp>",
   "license": "MIT",
   "dependencies": {
-    "minimist": "0.0.8",
-    "jwt-simple": "0.2.0",
-    "form-urlencoded": "0.0.6"
+    "form-urlencoded": "0.0.6",
+    "jwt-simple": "0.5.1",
+    "minimist": "0.0.8"
   },
   "devDependencies": {
     "eslint": "4.12.0",


### PR DESCRIPTION
Our dependencies are collecting dust. For starters, I went through all commits of jwt-simple between 0.2.0 and 0.5.1 (latest). Nothing should affect our codebase, but someone with a Google test-receipt would be well off giving it a whirl, just to be sure.