### PR TITLE
Add pending_renewal_info for Apple receipts

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,16 @@ or `latestReceiptInfo` property.
 			"is_trial_period": "true"
 		},
 	],
+	"pendingRenewalInfo": [
+		{
+		  "expiration_intent": "1",
+ 			"auto_renew_product_id": "abc",
+			"original_transaction_id": "120000233230473",
+			"is_in_billing_retry_period": "0",
+			"product_id": "abc",
+			"auto_renew_status": "0"
+		}
+	],
 	"transactionId": "120000233230473",
 	"productId": "abc",
 	"platform": "apple",

--- a/lib/apple/index.js
+++ b/lib/apple/index.js
@@ -62,6 +62,8 @@ function parseResult(result) {
 		getReceiptFieldValue(result.receipt, 'expires_date_ms') ||
 		getReceiptFieldValue(result.receipt, 'expires_date')
 	);
+	var latestExpiredReceiptInfo = getReceiptFieldValue(result, 'latest_expired_receipt_info');
+	var pendingRenewalInfo = getReceiptFieldValue(result, 'pending_renewal_info');
 
 	if (result.hasOwnProperty('latest_receipt_info')) {
 		if (Array.isArray(result.latest_receipt_info) && result.latest_receipt_info.length > 0) {
@@ -88,11 +90,12 @@ function parseResult(result) {
 	return {
 		receipt: result.receipt,
 		latestReceiptInfo: latestReceiptInfo,
-		latestExpiredReceiptInfo: result.latest_expired_receipt_info,
+		latestExpiredReceiptInfo: latestExpiredReceiptInfo,
 		productId: productId,
 		transactionId: transactionId,
 		purchaseData: purchaseData,
-		expirationDate: expirationDate
+		expirationDate: expirationDate,
+		pendingRenewalInfo: pendingRenewalInfo
 	};
 }
 


### PR DESCRIPTION
Add `pending_renewal_info` to Apple response if present and `null` if its not.
Also treat `latestExpiredReceiptInfo` the same.