### PR TITLE
 [Apple] Check for cancellation_date_ms first

### DIFF
--- a/lib/apple/index.js
+++ b/lib/apple/index.js
@@ -91,7 +91,12 @@ function parseResult(result) {
 		}
 	}
 
-	// Check for cancellation date
+	// If cancellation date is available it means that Apple Customer Support refunded subscription payment.
+	// From Apple:
+	// To check whether a purchase has been canceled by Apple Customer Support, look for the
+	// Cancellation Date field in the receipt. If the field contains a date, regardless of the 
+	// subscription’s expiration date, the purchase has been canceled. With respect to providing 
+	// content or service, treat a canceled transaction the same as if no purchase had ever been made.
 	if (latestExpiredReceiptInfo && latestExpiredReceiptInfo.cancellation_date_ms) {
 		expirationDate = parseTime(latestExpiredReceiptInfo.cancellation_date_ms);
 	}

--- a/lib/apple/index.js
+++ b/lib/apple/index.js
@@ -59,7 +59,6 @@ function parseResult(result) {
 	var transactionId = getReceiptFieldValue(result.receipt, 'transaction_id');
 	var purchaseData = parseTime(getReceiptFieldValue(result.receipt, 'purchase_date_ms'));
 	var expirationDate = parseTime(
-		getReceiptFieldValue(result.receipt, 'cancellation_date_ms') ||
 		getReceiptFieldValue(result.receipt, 'expires_date_ms') ||
 		getReceiptFieldValue(result.receipt, 'expires_date')
 	);
@@ -76,7 +75,6 @@ function parseResult(result) {
 			transactionId = lastReceipt.transaction_id;
 			purchaseData = parseTime(lastReceipt.purchase_date_ms);
 			expirationDate = parseTime(
-				lastReceipt.cancellation_date_ms ||
 				lastReceipt.expires_date_ms ||
 				lastReceipt.expires_date
 			);
@@ -87,11 +85,15 @@ function parseResult(result) {
 			transactionId = result.latest_receipt_info.transaction_id;
 			purchaseData = parseTime(result.latest_receipt_info.purchase_date_ms);
 			expirationDate = parseTime(
-				result.latest_receipt_info.cancellation_date_ms ||
 				result.latest_receipt_info.expires_date_ms ||
 				result.latest_receipt_info.expires_date
 			);
 		}
+	}
+
+	// Check for cancellation date
+	if (latestExpiredReceiptInfo && latestExpiredReceiptInfo.cancellation_date_ms) {
+		expirationDate = parseTime(latestExpiredReceiptInfo.cancellation_date_ms);
 	}
 
 	return {

--- a/lib/apple/index.js
+++ b/lib/apple/index.js
@@ -94,8 +94,8 @@ function parseResult(result) {
 	// If cancellation date is available it means that Apple Customer Support refunded subscription payment.
 	// From Apple:
 	// To check whether a purchase has been canceled by Apple Customer Support, look for the
-	// Cancellation Date field in the receipt. If the field contains a date, regardless of the 
-	// subscription’s expiration date, the purchase has been canceled. With respect to providing 
+	// Cancellation Date field in the receipt. If the field contains a date, regardless of the
+	// subscription’s expiration date, the purchase has been canceled. With respect to providing
 	// content or service, treat a canceled transaction the same as if no purchase had ever been made.
 	if (latestExpiredReceiptInfo && latestExpiredReceiptInfo.cancellation_date_ms) {
 		expirationDate = parseTime(latestExpiredReceiptInfo.cancellation_date_ms);

--- a/lib/apple/index.js
+++ b/lib/apple/index.js
@@ -59,6 +59,7 @@ function parseResult(result) {
 	var transactionId = getReceiptFieldValue(result.receipt, 'transaction_id');
 	var purchaseData = parseTime(getReceiptFieldValue(result.receipt, 'purchase_date_ms'));
 	var expirationDate = parseTime(
+		getReceiptFieldValue(result.receipt, 'cancellation_date_ms') ||
 		getReceiptFieldValue(result.receipt, 'expires_date_ms') ||
 		getReceiptFieldValue(result.receipt, 'expires_date')
 	);

--- a/lib/apple/index.js
+++ b/lib/apple/index.js
@@ -74,7 +74,11 @@ function parseResult(result) {
 			productId = lastReceipt.product_id;
 			transactionId = lastReceipt.transaction_id;
 			purchaseData = parseTime(lastReceipt.purchase_date_ms);
-			expirationDate = parseTime(lastReceipt.expires_date_ms || lastReceipt.expires_date);
+			expirationDate = parseTime(
+				lastReceipt.cancellation_date_ms ||
+				lastReceipt.expires_date_ms ||
+				lastReceipt.expires_date
+			);
 		} else if (result.latest_receipt_info && result.latest_receipt_info.transaction_id) {
 			latestReceiptInfo = [result.latest_receipt_info];
 
@@ -82,7 +86,9 @@ function parseResult(result) {
 			transactionId = result.latest_receipt_info.transaction_id;
 			purchaseData = parseTime(result.latest_receipt_info.purchase_date_ms);
 			expirationDate = parseTime(
-				result.latest_receipt_info.expires_date_ms || result.latest_receipt_info.expires_date
+				result.latest_receipt_info.cancellation_date_ms ||
+				result.latest_receipt_info.expires_date_ms ||
+				result.latest_receipt_info.expires_date
 			);
 		}
 	}


### PR DESCRIPTION
Apple says this about subscription cancellations:
https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/StoreKitGuide/Chapters/Subscriptions.html#//apple_ref/doc/uid/TP40008267-CH7-SW5

If a user cancels the subscription
>  Customers may cancel a subscription in the middle of a subscription period, but the subscription remains paid through the end of the same period.

If Apple customer support cancels the subscription and provides a refund
>To check whether a purchase has been canceled by Apple Customer Support, look for the Cancellation Date field in the receipt. If the field contains a date, regardless of the subscription’s expiration date, the purchase has been canceled. With respect to providing content or service, treat a canceled transaction the same as if no purchase had ever been made.

Based on this I think we should set the `expirationDate` to the cancellation date if a cancellation date is provided by Apple.

This is how a receipt looks like with a cancellation date:
```javascript
    {
        "original_purchase_date_pst": "2018-01-25 11:59:25 America/Los_Angeles",
        "cancellation_date_ms": "1517150504000",
        "cancellation_reason": "0",
        "original_purchase_date_ms": "1516910365000",
        "expires_date_formatted": "2019-01-25 19:59:23 Etc/GMT",
        "is_in_intro_offer_period": "false",
        "purchase_date_ms": "1516910363000",
        "expires_date_formatted_pst": "2019-01-25 11:59:23 America/Los_Angeles",
        "is_trial_period": "false",
        "expires_date": "1548446363000",
        "cancellation_date": "2018-01-28 14:41:44 Etc/GMT",
        "purchase_date": "2018-01-25 19:59:23 Etc/GMT",
        "cancellation_date_pst": "2018-01-28 06:41:44 America/Los_Angeles",
        "purchase_date_pst": "2018-01-25 11:59:23 America/Los_Angeles",
        "original_purchase_date": "2018-01-25 19:59:25 Etc/GMT"
    }
```

@KLVTZ @ronkorving what do you think?