### PR TITLE
reduce boilerplate in main module methods

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,12 +25,12 @@ function makeMethod(methodName) {
 		var engine = platforms[platform];
 
 		if (!engine) {
-			return asyncError('Platform ' + platform + ' not recognized');
+			return asyncError(`Platform ${platform} not recognized`);
 		}
 
 		if (!engine[methodName]) {
 			return asyncError(
-				'Platform ' + platform + ' does not have a ' + methodName + ' method'
+				`Platform ${platform} does not have a ${methodName} method`
 			);
 		}
 

--- a/index.js
+++ b/index.js
@@ -10,27 +10,23 @@ var platforms = {
 
 function makeMethod(methodName) {
 	exports[methodName] = function (platform, payment, cb) {
-		function asyncError(message) {
-			var error = new Error(message);
-			// this will cause the stack trace to start at the place where asyncError
-			// is called
-			error.captureStackTrace(error, asyncError);
-			process.nextTick(cb, error);
-		}
-
 		if (!payment) {
-			return asyncError('No payment given');
+			return process.nextTick(cb, new Error('No payment given'));
 		}
 
 		var engine = platforms[platform];
 
 		if (!engine) {
-			return asyncError(`Platform ${platform} not recognized`);
+			return process.nextTick(
+				cb,
+				new Error(`Platform ${platform} not recognized`)
+			);
 		}
 
 		if (!engine[methodName]) {
-			return asyncError(
-				`Platform ${platform} does not have a ${methodName} method`
+			return process.nextTick(
+				cb,
+				new Error(`Platform ${platform} does not have a ${methodName} method`)
 			);
 		}
 

--- a/index.js
+++ b/index.js
@@ -34,7 +34,15 @@ function makeMethod(methodName) {
 			);
 		}
 
-		engine[methodName](payment, cb);
+		engine[methodName](payment, function (error, result) {
+			if (error) {
+				return cb(error);
+			}
+
+			result = result.platform = platform;
+
+			cb(null, result);
+		});
 	};
 }
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.9.1",
   "description": "In-app purchase validation for Apple, Google, Amazon, Roku",
   "main": "index.js",
+  "engines" : {
+    "node" : ">= 6"
+  },
   "scripts": {
     "test": "eslint .",
     "precommit": "npm test"


### PR DESCRIPTION
following a to discussion in #55

since both `verifyPayment` and `cancelSubscription` in `index.js` were
basically identical, their implementation has been abstracted into
a helper function called `makeMethod`, which given a methods name, 
generates the body of the method and adds it to `exports`

The `syncError` helper has been renamed to `asyncError` and now accepts 
an error message instead of an `Error` object to reduce boilerplate 
when creating errors.