### PR TITLE
add missing platform property to result of cancelSubscription

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,6 +64,8 @@ exports.cancelSubscription = function (platform, payment, cb) {
 			return cb(error);
 		}
 
+		result.platform = platform;
+
 		cb(null, result);
 	});
 };


### PR DESCRIPTION
this bit of code was accidentally missed when cancelSubscription
was implemented by copy pasting implementation of verifyPayment