### PR TITLE
Validating against last purchased item instead of first one.

### DIFF
--- a/lib/apple/index.js
+++ b/lib/apple/index.js
@@ -24,8 +24,12 @@ function getReceiptFieldValue(receipt, field) {
 		return receipt[field];
 	}
 
-	if (receipt.hasOwnProperty('in_app') && receipt.in_app[0] && receipt.in_app[0].hasOwnProperty(field)) {
-		return receipt.in_app[0][field];
+	if (receipt.hasOwnProperty('in_app') && receipt.in_app[0]) {
+		// Find the last item purchased
+		var sorted = receipt.in_app.sort((a, b) => {
+			return b.purchase_date_ms - a.purchase_date_ms;
+		});
+		return sorted[0].hasOwnProperty(field) ? sorted[0][field] : null;
 	}
 
 	return null;


### PR DESCRIPTION
There's an issue when working with Grouped Subscriptions.

Suppose we have a Subscription group with 3 subscriptions: `sub1`, `sub2` and `sub3`.

The code originally validated against the first item of whatever Apple returned. The problem is that the list can contain any item of the group, thus, if the first purchase is for ID `abc1`, that's going to be the only item picked when validating the fields. Thus, if the last subscription purchased was for ID `sub3`, we will get an error when validating against the parameters sent to this module since the current `productId` would be `sub3`, yet it will be validated against the first item returned by Apple, with ID `sub1`.

Hope this helps. It's working on my side.