### PR TITLE
Removed old dependency and use nodejs builtin instead

### DIFF
--- a/lib/https/post.js
+++ b/lib/https/post.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var https = require('./index');
-var formUrlencoded = require('form-urlencoded');
+var querystring = require('querystring');
 
 module.exports = function (url, options, cb) {
 	options = options || {};
@@ -10,7 +10,7 @@ module.exports = function (url, options, cb) {
 	var data = null;
 	try {
 		if (options.form) {
-			data = formUrlencoded.encode(options.form);
+			data = querystring.stringify(options.form);
 			options.headers = {
 				'content-type': 'application/x-www-form-urlencoded',
 				'content-length': Buffer.byteLength(data)

--- a/package-lock.json
+++ b/package-lock.json
@@ -150,7 +150,7 @@
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
       "dev": true,
       "requires": {
-        "color-name": "^1.1.1"
+        "color-name": "1.1.3"
       }
     },
     "color-name": {
@@ -390,11 +390,6 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.0.tgz",
       "integrity": "sha512-R+H8IZclI8AAkSBRQJLVOsxwAoHd6WC40b4QTNWIjzAa6BXOBfQcM587MXDTVPeYaopFNWHUFLx7eNmHDSxMWg==",
       "dev": true
-    },
-    "form-urlencoded": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/form-urlencoded/-/form-urlencoded-0.0.6.tgz",
-      "integrity": "sha1-kr37GJ3KtHTyCRcvpT5tiInXPr8="
     },
     "fs.realpath": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -150,7 +150,7 @@
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
       "dev": true,
       "requires": {
-        "color-name": "1.1.3"
+        "color-name": "^1.1.1"
       }
     },
     "color-name": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   "author": "Ron Korving <rkorving@wizcorp.jp>",
   "license": "MIT",
   "dependencies": {
-    "form-urlencoded": "0.0.6",
     "jwt-simple": "0.5.6",
     "minimist": "0.0.8"
   },


### PR DESCRIPTION
Currently node-iap is using an old version of [form-urlencoded](https://www.npmjs.com/package/form-urlencoded), this PR removes this third party dependency and uses the nodejs builtin [querystring](https://nodejs.org/api/querystring.html) which will accomplish the same thing and reduce the outside dependency.

I am specifically using `.stringify()` instead of `.encode()` on querystring because encode is simply just an alias for stringify and stringify was the original function name in node so it has backwards compatibility back to Node v4.9.1 according to their docs