### PR TITLE
Changed Google API URLs to use version 3 of the API

### DIFF
--- a/lib/google/urls.js
+++ b/lib/google/urls.js
@@ -13,7 +13,7 @@ exports.publisherScope = 'https://www.googleapis.com/auth/androidpublisher';
 
 // Android Purchases URLs & generators
 exports.purchasesProductsGet = function (packageName, productId, receipt, accessToken) {
-	var urlFormat = 'https://www.googleapis.com/androidpublisher/v2/applications/%s/purchases/products/%s/tokens/%s?access_token=%s';
+	var urlFormat = 'https://www.googleapis.com/androidpublisher/v3/applications/%s/purchases/products/%s/tokens/%s?access_token=%s';
 
 	return util.format(
 		urlFormat,
@@ -27,7 +27,7 @@ exports.purchasesProductsGet = function (packageName, productId, receipt, access
 
 // Android Subscriptions URLs & generators
 exports.purchasesSubscriptionsGet = function (packageName, productId, receipt, accessToken) {
-	var urlFormat = 'https://www.googleapis.com/androidpublisher/v2/applications/%s/purchases/subscriptions/%s/tokens/%s?access_token=%s';
+	var urlFormat = 'https://www.googleapis.com/androidpublisher/v3/applications/%s/purchases/subscriptions/%s/tokens/%s?access_token=%s';
 
 	return util.format(
 		urlFormat,
@@ -41,7 +41,7 @@ exports.purchasesSubscriptionsGet = function (packageName, productId, receipt, a
 
 // Android Subscriptions URLs & generators
 exports.purchasesSubscriptionsCancel = function (packageName, productId, receipt, accessToken) {
-	var urlFormat = 'https://www.googleapis.com/androidpublisher/v2/applications/%s/purchases/subscriptions/%s/tokens/%s:cancel?access_token=%s';
+	var urlFormat = 'https://www.googleapis.com/androidpublisher/v3/applications/%s/purchases/subscriptions/%s/tokens/%s:cancel?access_token=%s';
 
 	return util.format(
 		urlFormat,


### PR DESCRIPTION
The update to version 3 of the Google API is to my best knowledge just using a different URL in our case. I tried validating a purchase with the updated URLs and the behaviour is exactly the same. I could not test the subscription related calls, but the documentation also states no difference between the two versions.

If someone has a hint on how to test the change more thoroughly, I'm happy to follow up. :) 