### PR TITLE
Update available response status codes from apple

### DIFF
--- a/lib/apple/index.js
+++ b/lib/apple/index.js
@@ -16,7 +16,9 @@ const responses = {
 	21005: 'The receipt server is not currently available.',
 	21006: 'This receipt is valid but the subscription has expired. When this status code is returned to your server, the receipt data is also decoded and returned as part of the response.',
 	21007: 'This receipt is from the test environment, but it was sent to the production service for verification. Send it to the test environment service instead.',
-	21008: 'This receipt is from the production receipt, but it was sent to the test environment service for verification. Send it to the production environment service instead.'
+	21008: 'This receipt is from the production receipt, but it was sent to the test environment service for verification. Send it to the production environment service instead.',
+	21009: 'Internal data access error. Try again later.',
+	21010: 'The user account cannot be found or has been deleted.'
 };
 
 function getReceiptFieldValue(receipt, field) {


### PR DESCRIPTION
Referencing the following documentation:

https://developer.apple.com/documentation/appstorereceipts/status

We can see that 21009 and 21010 are available codes we should handle.